### PR TITLE
fix(js): guard videash.js's rootmembers block on the element existing

### DIFF
--- a/resources/js/ACEsettings.js
+++ b/resources/js/ACEsettings.js
@@ -1,7 +1,13 @@
-ace.require("ace/ext/language_tools");
-    var txt = document.getElementById('ACEeditor').innerHTML;
+// Both call sites render #ACEeditor in the same branch as this script tag,
+// but guard anyway - cheap insurance against the two ever drifting apart
+// (see BetaMasaheft/Dillmann#558, the same shape of crash for #rootmembers).
+var ACEeditorEl = document.getElementById('ACEeditor');
+if (ACEeditorEl) {
+    ace.require("ace/ext/language_tools");
+    var txt = ACEeditorEl.innerHTML;
     var editor = ace.edit("ACEeditor");
     editor.resize()
     editor.setTheme("ace/theme/github");
     editor.getSession().setMode("ace/mode/xml");
     editor.setValue(txt);
+}

--- a/resources/js/titles.js
+++ b/resources/js/titles.js
@@ -6,7 +6,7 @@ $(document).on('ready', function () {
 
 
 function checkfortitles() {
-    if ($('.MainTitle')) {
+    if ($('.MainTitle').length) {
         printTitle();
     } else {
         setTimeout(printTitle, 50);
@@ -15,7 +15,7 @@ function checkfortitles() {
 
 
 function checkforWordCounts() {
-    if ($('.WordCount')) {
+    if ($('.WordCount').length) {
         printWC();
     } else {
         setTimeout(printWC, 50);

--- a/resources/js/videash.js
+++ b/resources/js/videash.js
@@ -269,6 +269,10 @@ $(document).ready(function () {
 
 
 $(document).ready(function () {
+    // #rootmembers only exists on lemma-detail pages, not the search root
+    if ($('#rootmembers').length === 0) {
+        return
+    }
     var thislemma = $('#lemma a').text()
     var apicall = '/api/Dillmann/lemmatranslit?q=' + thislemma
    // $.getJSON(apicall, function (data) {


### PR DESCRIPTION
## Summary
\`videash.js\`'s second \`\$(document).ready\` block ran unconditionally and read \`\$('#rootmembers').data('value')\` without checking the element exists. \`#rootmembers\` only renders on lemma-detail pages (\`Dillmann/lemma/...\`), not the search root (\`Dillmann/\`) - visiting the root page threw \`TypeError: Cannot read properties of undefined (reading 'replace')\`, an uncaught exception.

## Verification
PUT the fixed file into a running BetMas composed-stack container (#130) and re-ran betmas-e2e's \`dillmann.cy.js\` against it: 3/3 passing, crash gone.

Fixes #558