### PR TITLE
fix(ci): publish.yml points at the wrong PAT secret

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ name: Publish Docker image
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -35,7 +36,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: betmas-bot
-          password: ${{ secrets.CI_BOT_PAT }}
+          password: ${{ secrets.BOT_CONTAINER_PAT }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
## Summary
\`publish.yml\` (merged via #560) built successfully but every push to ghcr failed: \`denied: permission_denied: The token provided does not match expected scopes.\` \`secrets.CI_BOT_PAT\` doesn't have package-write scope.

Switched to \`BOT_CONTAINER_PAT\` - the org secret already used for this exact purpose by BetMas/BetMasWeb (now also granted repo access to Dillmann). Also added \`workflow_dispatch\` so this can be tested/re-run manually instead of only firing on push to master.

## Verification
Manually dispatched on this branch: build + push both succeeded, pulled the resulting image locally (\`ghcr.io/betamasaheft/dillmann:dp-fix-publish-pat\`).

Doesn't close #556 - the epic's actual goal (Dillmann as an optional profile, not baked into BetMas's always-on build stage) is unaffected by this; this just makes the prerequisite published image actually exist.